### PR TITLE
add altair signing domains

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -39,6 +39,12 @@ var (
 	DomainSelectionProof = DomainType{5, 0, 0, 0}
 	// DomainAggregateAndProof is a domain constant.
 	DomainAggregateAndProof = DomainType{6, 0, 0, 0}
+	// DomainSyncCommittee is a domain constant.
+	DomainSyncCommittee = DomainType{7, 0, 0, 0}
+	// DomainSyncCommitteeSelectionProof is a domain constant.
+	DomainSyncCommitteeSelectionProof = DomainType{8, 0, 0, 0}
+	// DomainContributionAndProof is a domain constant.
+	DomainContributionAndProof = DomainType{9, 0, 0, 0}
 )
 
 // ComputeDomain computes a domain.


### PR DESCRIPTION
Adds new altair domain constants from eth consensus spec.

https://github.com/ethereum/consensus-specs/blob/f221674be4d6aad14bbb170efbbbba6a4c58e6cf/specs/altair/beacon-chain.md#constants