### PR TITLE
Added DomainBlsToExecutionChange

### DIFF
--- a/domain.go
+++ b/domain.go
@@ -45,6 +45,8 @@ var (
 	DomainSyncCommitteeSelectionProof = DomainType{8, 0, 0, 0}
 	// DomainContributionAndProof is a domain constant.
 	DomainContributionAndProof = DomainType{9, 0, 0, 0}
+	// DomainBlsToExecutionChange is a domain constant.
+	DomainBlsToExecutionChange = DomainType{0x0A, 0, 0, 0}
 )
 
 // ComputeDomain computes a domain.


### PR DESCRIPTION
This simply adds the BLS to Execution Change domain from the [Capella spec](https://github.com/ethereum/consensus-specs/blob/master/specs/capella/beacon-chain.md#domain-types).